### PR TITLE
fix: Изменил стили кнопки, добавил новые модификаторы

### DIFF
--- a/blocks/button/button.css
+++ b/blocks/button/button.css
@@ -1,6 +1,7 @@
 .button {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   text-transform: uppercase;
   font-family: var(--body-font);
   color: var(--base-color);
@@ -27,26 +28,21 @@
   z-index: 1;
   background-color: var(--base-color);
   mix-blend-mode: screen;
-  /* mix-blend-mode: exclusion; */
+  backdrop-filter: invert(1);
 }
 
 .button:hover::before, .button:active:not(:hover)::before {
   right: 0;
 }
 
-.button:hover, .button:active:not(:hover) {
-  color: #dbdbdb;
-}
-
 @media (any-hover: hover) {
   .button:active {
-    box-shadow: 0 0 0 2px var(--base-color);
+    box-shadow: 0 0 0 3px var(--base-color);
   }
 }
 
 .button_size_big {
   padding: 16px;
-  justify-content: space-between;
 }
 
 .button_type_big-arr-ltr {
@@ -63,8 +59,28 @@
   background-size: cover;
 }
 
-.button_type_big-arr-ltr:hover::after, .button_type_big-arr-ltr:active:not(:hover)::after  {
-  background-image: url("data:image/svg+xml,%3Csvg width='21' height='13' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M21 6.47656L20.2752 7.20139L14.4766 13L13.7737 12.2971L19.0944 6.97646L-3.63036e-07 6.97646L-3.10999e-07 5.97646L19.0502 5.97646L13.7986 0.724826L14.5234 -2.37804e-07L20.2971 5.77369L21 6.47656Z' fill='%23dbdbdb'/%3E%3C/svg%3E%0A");
+.button_type_big-arr-lbtrt, .button_type_big-arr-ttb {
+  box-shadow: 0 -1px 0 0 var(--base-color);
+}
+
+.button_type_big-arr-lbtrt::after {
+  content: '';
+  background-image: url("data:image/svg+xml,%3Csvg width='25' height='25' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M19.909 5.059v9.225h-.994V6.76L5.413 20.262l-.707-.707 13.47-13.471H10.75V5.059H19.908Z' fill='%23242424'/%3E%3C/svg%3E");
+  width: 25px;
+  height: 25px;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+.button_type_big-arr-ttb::after {
+  content: '';
+  background-image: url("data:image/svg+xml,%3Csvg width='25' height='25' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='m12.523 21-.724-.725L6 14.477l.703-.703 5.32 5.32V0h1v19.05l5.252-5.251.725.724-5.774 5.774-.703.703Z' fill='%23242424'/%3E%3C/svg%3E");
+  width: 25px;
+  height: 25px;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
 }
 
 .button_type_arr-right-rtl {
@@ -84,10 +100,6 @@
   background-size: cover;
 }
 
-.button_type_arr-right-rtl:hover::after, .button_type_arr-right-rtl:active:not(:hover)::after  {
-  background-image: url("data:image/svg+xml,%3Csvg width='21' height='13' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M0 6.523.725 5.8 6.523 0l.703.703-5.32 5.32H21v1H1.95L7.2 12.276 6.477 13 .703 7.226 0 6.523Z' fill='%23dbdbdb'/%3E%3C/svg%3E");
-}
-
 .button_type_arr-left-ltr {
   flex-direction: row-reverse;
   justify-content: start;
@@ -104,8 +116,4 @@
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
-}
-
-.button_type_arr-left-ltr:hover::after, .button_type_arr-left-ltr:active:not(:hover)::after {
-  background-image: url("data:image/svg+xml,%3Csvg width='21' height='13' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='m21 6.477-.725.724L14.477 13l-.703-.703 5.32-5.32H0v-1h19.05L13.8.724 14.523 0l5.774 5.774.703.703Z' fill='%23dbdbdb'/%3E%3C/svg%3E");
 }


### PR DESCRIPTION
Убрал костыльные решения для наведения. Теперь кнопка работает ровно как в стайлгайде:
<img width="96" alt="image" src="https://user-images.githubusercontent.com/105359320/197400624-13a3d3bc-a1ea-4ada-834b-50d86dbb3312.png">
но в фаерфоксе и сафари выглядит чуть хуже при наведении (не поддерживают backdrop-filter):
<img width="103" alt="image" src="https://user-images.githubusercontent.com/105359320/197400553-26a89e1d-fc8c-4178-b6c5-e60868efbcfa.png">


Добавил модификаторы для кнопок в блоке с пьесами.
`button_size_big` - делает кнопку с большими отступами,
`button_type_big-arr-lbtrt` - добавляет стрелку справа (lbtrt - Left-Bottom To Right-Top - вправо--вверх)
`button_type_big-arr-ttb` - добавляет стрелку справа (ttb - Top To Bottom - вниз)